### PR TITLE
Add OS-dependent LWJGL native library support

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,15 @@ version = "1.0-SNAPSHOT"
 val lwjglVersion = "3.3.1"
 val javafxVersion = "17"
 
+// OS-dependent LWJGL Natives
+val osName = System.getProperty("os.name").lowercase()
+val lwjglNatives = when {
+	osName.contains("windows") -> "natives-windows"
+	osName.contains("linux") -> "natives-linux"
+	osName.contains("mac") -> "natives-macos"
+	else -> throw GradleException("Unsupported OS: $osName")
+}
+
 java {
 	sourceCompatibility = JavaVersion.toVersion("17")
 	targetCompatibility = JavaVersion.toVersion("17")
@@ -27,11 +36,11 @@ dependencies {
 	implementation("org.lwjgl:lwjgl-glfw:$lwjglVersion")
 	implementation("org.lwjgl:lwjgl-stb:$lwjglVersion")
 
-	// LWJGL Native Libraries for Windows
-	implementation("org.lwjgl:lwjgl:$lwjglVersion:natives-windows")
-	implementation("org.lwjgl:lwjgl-openal:$lwjglVersion:natives-windows")
-	implementation("org.lwjgl:lwjgl-glfw:$lwjglVersion:natives-windows")
-	implementation("org.lwjgl:lwjgl-stb:$lwjglVersion:natives-windows")
+	// LWJGL Native Libraries
+	implementation("org.lwjgl:lwjgl:$lwjglVersion:$lwjglNatives")
+	implementation("org.lwjgl:lwjgl-openal:$lwjglVersion:$lwjglNatives")
+	implementation("org.lwjgl:lwjgl-glfw:$lwjglVersion:$lwjglNatives")
+	implementation("org.lwjgl:lwjgl-stb:$lwjglVersion:$lwjglNatives")
 
 	// Gson
 	implementation("com.google.code.gson:gson:2.10")


### PR DESCRIPTION
Updated the Gradle build configuration to include OS-specific LWJGL native libraries. Previously, only Windows natives were included, causing runtime errors on Linux and macOS.

* Added logic to detect the current OS and select the appropriate LWJGL natives (`natives-windows`, `natives-linux`, `natives-macos`).
* Replaced hardcoded Windows natives with the OS-dependent configuration.
* Ensures the game can run on Windows, Linux, and macOS without manual adjustments to the build script.
